### PR TITLE
Single Picture & YGL hard limit fixes

### DIFF
--- a/lib/you_got_listed.rb
+++ b/lib/you_got_listed.rb
@@ -4,6 +4,7 @@ require 'hashie'
 require 'rash'
 require 'will_paginate/collection'
 require 'active_support/core_ext/array/grouping'
+require 'active_support/core_ext/object/blank'
 
 require 'you_got_listed/client'
 require 'you_got_listed/resource'

--- a/lib/you_got_listed/listing.rb
+++ b/lib/you_got_listed/listing.rb
@@ -50,7 +50,7 @@ module YouGotListed
     end
     
     def pictures
-      self.photos.photo unless self.photos.blank? || self.photos.photo.blank?
+      (self.photos.photo.is_a?(Array) ? self.photos.photo : [self.photos.photo])  unless self.photos.blank? || self.photos.photo.blank?
     end
     
     def main_picture

--- a/lib/you_got_listed/listings.rb
+++ b/lib/you_got_listed/listings.rb
@@ -52,10 +52,10 @@ module YouGotListed
       if listing_ids.any?{|list_id| list_id !=~ /[A-Z]{3}-[0-9]{3}-[0-9]{3}/}
         search_params[:include_mls] = 1
       end
-      listing_ids.in_groups_of(500, false).each_with_index do |group, index|
+      # YGL no longer allows you to pass page_count > 10, so we're stuck paging
+      listing_ids.in_groups_of(10, false).each_with_index do |group, index|
         group.delete_if{|x| x.nil?}
         search_params[:listing_ids] = group.join(',')
-        search_params[:page_count] = 500
         search_params[:page_index] = index + 1
         all_listings << find_all(search_params)
       end

--- a/spec/you_got_listed/listing_spec.rb
+++ b/spec/you_got_listed/listing_spec.rb
@@ -81,6 +81,14 @@ describe YouGotListed::Listing do
       @listing.stub!(:pictures).and_return(nil)
       @listing.main_picture.should be_nil
     end
+    
+    it "should return an array if the property has only one photo" do
+      rash = valid_listing_rash
+      rash[:photos].merge!(:photo => 'http://ygl-photos.s3.amazonaws.com/1236380.jpg')
+      @listing = YouGotListed::Listing.new(rash, @ygl)
+      @listing.pictures.is_a?(Array).should be_true
+      @listing.main_picture.should == 'http://ygl-photos.s3.amazonaws.com/1236380.jpg'
+    end
   end
   
   context "latitude" do


### PR DESCRIPTION
Pictures method returns an array instead of a string when only one picture is present on a property.

Account for new YGL hard limit of 10 properties per search.
